### PR TITLE
Python3 gives OSError AND ImportError when libdiscid is not found

### DIFF
--- a/discid.py
+++ b/discid.py
@@ -76,7 +76,9 @@ def _open_library(lib_name):
     try:
         return ctypes.cdll.LoadLibrary(lib_name)
     except OSError as err:
-        raise ImportError(err)
+        import_error = ImportError(err)
+        import_error.__suppress_context__ = True
+        raise import_error
 
 _LIB_NAME = _find_library(_LIB_BASE_NAME, _LIB_MAJOR_VERSION)
 _LIB = _open_library(_LIB_NAME)


### PR DESCRIPTION
That is not what we want, because we give the message from the `OSError` anyways and having 2 exceptions just clutters the output.
