### PR TITLE
update submission url for NGS

### DIFF
--- a/discid/disc.py
+++ b/discid/disc.py
@@ -274,10 +274,13 @@ class Disc(object):
         This is a :obj:`unicode` or :obj:`str <python:str>` object.
         """
         url = self._get_submission_url()
-        # update submission url, which saves a couple of redirects
-        url = url.replace("//mm.", "//")
-        url = url.replace("/bare/cdlookup.html", "/cdtoc/attach")
-        return url
+        if url is None:
+            return None
+        else:
+            # update submission url, which saves a couple of redirects
+            url = url.replace("//mm.", "//")
+            url = url.replace("/bare/cdlookup.html", "/cdtoc/attach")
+            return url
 
     @property
     def first_track_num(self):


### PR DESCRIPTION
The url given by libdiscid also works, but is redirected.
This saves the redirection.
