### PR TITLE
Don't make DEFAULT_DEVICE a constant

### DIFF
--- a/discid/__init__.py
+++ b/discid/__init__.py
@@ -29,6 +29,7 @@ and will raise :exc:`OSError` when libdiscid is not found.
 
 from discid.disc import read, put, Disc, DiscError, TOCError
 from discid.track import Track
+from discid.libdiscid import get_default_device
 from discid.deprecated import DiscId
 import discid.libdiscid
 import discid.disc
@@ -41,11 +42,6 @@ __version__ = "0.5.0"
 LIBDISCID_VERSION_STRING = discid.libdiscid.LIBDISCID_VERSION_STRING
 """The version string of the loaded libdiscid in the form `libdiscid x.y.z`.
 For old versions the string is `libdiscid < 0.4.0`.
-"""
-
-DEFAULT_DEVICE = discid.libdiscid.DEFAULT_DEVICE
-"""The default device to use for :func:`read` on this platform
-given as a :obj:`unicode` or :obj:`str <python:str>` object.
 """
 
 FEATURES = discid.libdiscid.FEATURES

--- a/discid/disc.py
+++ b/discid/disc.py
@@ -38,7 +38,8 @@ def read(device=None, features=[]):
     That string can be either of:
     :obj:`str <python:str>`, :obj:`unicode` or :obj:`bytes`.
     However, it should in no case contain non-ASCII characters.
-    If no device is given, the :data:`DEFAULT_DEVICE` is used.
+    If no device is given, a default, also given by :func:`get_default_device`
+    is used.
 
     You can optionally add a subset of the features in
     :data:`FEATURES` or the whole list to read more than just the TOC.

--- a/discid/libdiscid.py
+++ b/discid/libdiscid.py
@@ -120,8 +120,9 @@ def _get_version_string():
 
 _LIB.discid_get_default_device.argtypes = ()
 _LIB.discid_get_default_device.restype = c_char_p
-def _get_default_device():
-    """Get the default device for the platform
+def get_default_device():
+    """The default device to use for :func:`read` on this platform
+    given as a :obj:`unicode` or :obj:`str <python:str>` object.
     """
     device = _LIB.discid_get_default_device()
     return _decode(device)
@@ -163,8 +164,6 @@ def _get_features():
     return features
 
 LIBDISCID_VERSION_STRING = _get_version_string()
-
-DEFAULT_DEVICE = _get_default_device()
 
 FEATURES = _get_features()
 

--- a/doc/discid.rst
+++ b/doc/discid.rst
@@ -10,8 +10,6 @@ At the module level there are these constants available:
 
 .. autodata:: LIBDISCID_VERSION_STRING
    :annotation:
-.. autodata:: DEFAULT_DEVICE
-   :annotation:
 .. autodata:: FEATURES
    :annotation:
 .. autodata:: FEATURES_IMPLEMENTED
@@ -23,11 +21,14 @@ These functions are used to create a :class:`Disc` object.
 .. autofunction:: read
 .. autofunction:: put
 
+You can get the device that is used as a default with
+
+.. autofunction:: get_default_device
+
 Disc object
 -----------
 .. autoclass:: Disc
    :undoc-members:
-
 
    .. autoattribute:: id
    .. autoattribute:: freedb_id

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -8,14 +8,14 @@ The basic use case is::
  # this will load libdiscid
  import discid
 
- print("device: %s" % discid.DEFAULT_DEVICE)
+ print("device: %s" % discid.get_default_device())
  disc = discid.read()        # reads from default device
  print("id: %s" % disc.id)
  print("submission url:\n%s" % disc.submission_url)
 
 You can also set the device explicitely::
 
- device = discid.DEFAULT_DEVICE
+ device = discid.get_default_device()
  disc = discid.read(device)
  id = disc.id
 

--- a/examples.py
+++ b/examples.py
@@ -8,7 +8,7 @@ import discid
 def simple_example():
     disc = discid.read()       # use default device
     print("id: %s" % disc.id)
-    print("used %s as device" % discid.DEFAULT_DEVICE)
+    print("used %s as device" % discid.get_default_device())
     print("submit with:\n%s" % disc.submission_url)
 
 

--- a/test_discid.py
+++ b/test_discid.py
@@ -50,7 +50,7 @@ class TestModule(unittest.TestCase):
         self.assertTrue(version_string is not None, "No version string given")
 
     def test_default_device(self):
-        device = discid.DEFAULT_DEVICE
+        device = discid.get_default_device()
         self.assertTrue(device is not None, "No default device given")
 
     def test_features(self):
@@ -129,7 +129,7 @@ class TestDisc(unittest.TestCase):
 
     def test_default_device(self):
         # Can't be empty, in contrast to the test in TestModule
-        device = discid.DEFAULT_DEVICE
+        device = discid.get_default_device()
         self.assertTrue(device, "No default device given")
 
     def test_features(self):


### PR DESCRIPTION
I would consider not to have a DEFAULT_DEVICE constant but rather do an actual function call. Even though the default device is at the moment mostly a constant in libdiscid, it might be something which changes on runtime.

I am not entirely sure how OSX handles the devices, but isn't it the case there that the devices change on runtime when the users inserts / removes a disc? At least https://github.com/metabrainz/libdiscid/blob/master/src/disc_darwin.c#L155 suggest this and   Picard has issues with it. Even on other systems that could happen when the user attaches a portable drive, even though dynamic detection of the device is currently not supported by libdiscid on those platforms.
