### PR TITLE
re-add DEFAULT_DEVICE additionally as deprecated

### DIFF
--- a/discid/__init__.py
+++ b/discid/__init__.py
@@ -30,11 +30,11 @@ and will raise :exc:`OSError` when libdiscid is not found.
 from discid.disc import read, put, Disc, DiscError, TOCError
 from discid.track import Track
 from discid.libdiscid import get_default_device
-from discid.deprecated import DiscId
+from discid.deprecated import DiscId, DEFAULT_DEVICE
 import discid.libdiscid
 import discid.disc
 
-__version__ = "1.0.0"
+__version__ = "1.0.0-dev"
 
 
 # these contants are defined here so sphinx can catch the "docstrings"

--- a/discid/deprecated.py
+++ b/discid/deprecated.py
@@ -18,13 +18,21 @@
 """Deprecated functions and classes
 """
 
-from warnings import warn, simplefilter
+from warnings import warn, warn_explicit, simplefilter
 
 from discid.disc import Disc
+from discid.libdiscid import get_default_device
 
 # turn on DeprecationWarnings for DiscId below
 simplefilter(action="once", category=DeprecationWarning)
 
+def _default_device_constant():
+    warn_explicit("DEFAULT_DEVICE is deprecated.\n"
+         "Use get_default_device() instead",
+         DeprecationWarning, None, 0)
+    return get_default_device()
+
+DEFAULT_DEVICE = _default_device_constant()
 
 class DiscId(Disc):
     """Deprecated class, use :func:`read` or :func:`put` or :class:`Disc`.


### PR DESCRIPTION
Well, python-discid prior to 1.0.0 was a beta release, but maybe we could provide the old API for convenience when we print a deprecation warning anyways.
