### PR TITLE
deprecation warning for DEFAULT_DEVICE shows always

### DIFF
--- a/discid/__init__.py
+++ b/discid/__init__.py
@@ -30,7 +30,7 @@ and will raise :exc:`OSError` when libdiscid is not found.
 from discid.disc import read, put, Disc, DiscError, TOCError
 from discid.track import Track
 from discid.libdiscid import get_default_device
-from discid.deprecated import DiscId, DEFAULT_DEVICE
+from discid.deprecated import DiscId
 import discid.libdiscid
 import discid.disc
 

--- a/discid/deprecated.py
+++ b/discid/deprecated.py
@@ -18,21 +18,13 @@
 """Deprecated functions and classes
 """
 
-from warnings import warn, warn_explicit, simplefilter
+from warnings import warn, simplefilter
 
 from discid.disc import Disc
-from discid.libdiscid import get_default_device
 
 # turn on DeprecationWarnings for DiscId below
 simplefilter(action="once", category=DeprecationWarning)
 
-def _default_device_constant():
-    warn_explicit("DEFAULT_DEVICE is deprecated.\n"
-         "Use get_default_device() instead",
-         DeprecationWarning, None, 0)
-    return get_default_device()
-
-DEFAULT_DEVICE = _default_device_constant()
 
 class DiscId(Disc):
     """Deprecated class, use :func:`read` or :func:`put` or :class:`Disc`.


### PR DESCRIPTION
I did check that the deprecationWarning works, but I didn't see until the release that this triggers on any `import discid` because python-discid is the one using the function that triggers the warning.
That is: #34 doesn't work as expected.

it looks like there is no way to trigger a deprecation warning for constants at all.

So we either include it without warning, possibly having this remain in scripts without problems until I remove it completely
or I just remove DEFAULT_DEVICE.

There might be weird workarounds with returning something special as DEFAULT_DEVICE and detecting this in read and issue the warning then, but that is a mess to maintain and the warning isn't displayed when the constant is used, but later on (or possibly never).
