### PR TITLE
not working in dmg (Mac OS X bundle)

### DIFF
--- a/discid/libdiscid.py
+++ b/discid/libdiscid.py
@@ -40,6 +40,12 @@ def _find_library(name, version=0):
 
     lib_file = None
 
+    # This seems to be necessary in a bundle/dmg
+    if sys.platform == "darwin":
+        lib_name = '../Frameworks/lib%s.%d.dylib' % (name, version)
+        if os.path.isfile(lib_name):
+            lib_file = lib_name
+
     # force prefer current folder
     # for linux/UNIX-like and Windows
     if sys.platform in ["darwin", "cygwin"]:


### PR DESCRIPTION
On Mac OS X a dylib in `./Content/Frameworks` can't be found when python-discid and libdiscid are in a bundle (dmg/app). The example is when in included in MusicBrainz Picard.

See:
http://chatlogs.musicbrainz.org/musicbrainz-devel/2014/2014-02/2014-02-12.html#T16-12-10-392641
