### PR TITLE
Add Disc.cddb_query_string property

### DIFF
--- a/discid/disc.py
+++ b/discid/disc.py
@@ -368,6 +368,24 @@ class Disc(object):
         return tracks
 
 
+    @property
+    def cddb_query_string(self):
+        """A CDDB query string suitable for querying CDDB servers.
+
+        This is a :obj:`unicode` or :obj:`str <python:str>` object
+        and enables generating queries to CDDB servers.
+
+        .. seealso:: `CDDB Server Protocol <http://ftp.freedb.org/pub/freedb/latest/CDDBPROTO>`_
+        """
+        cddb_query_string = "%s %s %s %s" % (
+            self.freedb_id,
+            self.last_track_num,
+            " ".join([str(track.offset) for track in self.tracks]),
+            self.seconds,
+        )
+        return cddb_query_string
+
+
     _LIB.discid_free.argtypes = (c_void_p, )
     _LIB.discid_free.restype = None
     def _free(self):

--- a/test_discid.py
+++ b/test_discid.py
@@ -103,6 +103,9 @@ class TestModule(unittest.TestCase):
         toc_string = ["1", disc.last_track_num, disc.sectors] + track_offsets
         toc_string = " ".join(map(str, toc_string))
         self.assertEqual(disc.toc_string, toc_string)
+        cddb_query_string = [disc.freedb_id, disc.last_track_num] + track_offsets + [disc.seconds]
+        cddb_query_string = " ".join(map(str, cddb_query_string))
+        self.assertEqual(disc.cddb_query_string, cddb_query_string)
 
 
 class TestDisc(unittest.TestCase):
@@ -152,6 +155,7 @@ class TestDisc(unittest.TestCase):
         sectors = disc.sectors
         track_sectors = [track.sectors for track in disc.tracks]
         track_offsets = [track.offset for track in disc.tracks]
+        cddb_query_string = disc.cddb_query_string
 
         disc = discid.put(first, last, sectors, track_offsets)
         self.assertEqual(disc.id, disc_id, "different id after put")
@@ -173,6 +177,8 @@ class TestDisc(unittest.TestCase):
         new_sectors = [track.sectors for track in disc.tracks]
         self.assertEqual(new_sectors, track_sectors,
                          "different lengths after put")
+        self.assertEqual(disc.cddb_query_string, cddb_query_string,
+                         "different cddb_query_string after put")
 
     def test_read_features(self):
         disc = discid.read(features=["mcn", "isrc"]) # read from default drive


### PR DESCRIPTION
Adds a CDDB query compatible string for generating queries against CDDB servers.

Useful together with e.g., https://github.com/cbxbiker61/python-cddb