### PR TITLE
Added Disc.pregap property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 Changes in 1.4.0 (unreleased):
 ------------------------------
  * Added type hints to the public API for better IDE support and type checking.
+ * Added :attr:`Disc.pregap` property.
  * Fixed: mutable default arguments in function signatures.
  * Accept any ``Sequence[int]`` for ``offsets`` in :func:`put`.
  * Removed Python 2 specific code and comments.

--- a/discid/disc.py
+++ b/discid/disc.py
@@ -362,6 +362,17 @@ class Disc:
         return self._get_last_track_num()
 
     @property
+    def pregap(self) -> int:
+        """Pregap of the first track in sectors.
+
+        This corresponds to the offset of the first track. A pregap of 150
+        sectors is typical for a CD and does not indicate any intentional gap
+        before the first track.
+        """
+        track = Track(self, self._get_first_track_num())
+        return track.offset
+
+    @property
     def sectors(self) -> int:
         """Total length in sectors"""
         return self._get_sectors()

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -36,6 +36,17 @@ Disc object
 
    .. autoproperty:: id
    .. autoproperty:: freedb_id
+   .. autoproperty:: first_track_num
+   .. autoproperty:: last_track_num
+   .. autoproperty:: pregap
+
+      .. versionadded:: 1.4
+
+   .. autoproperty:: sectors
+   .. autoproperty:: length
+   .. autoproperty:: seconds
+   .. autoproperty:: mcn
+   .. autoproperty:: tracks
    .. autoproperty:: submission_url
    .. autoproperty:: toc_string
 
@@ -44,14 +55,6 @@ Disc object
    .. autoproperty:: cddb_query_string
 
       .. versionadded:: 1.3
-
-   .. autoproperty:: first_track_num
-   .. autoproperty:: last_track_num
-   .. autoproperty:: sectors
-   .. autoproperty:: length
-   .. autoproperty:: seconds
-   .. autoproperty:: mcn
-   .. autoproperty:: tracks
 
 Track object
 ------------

--- a/test_discid.py
+++ b/test_discid.py
@@ -80,6 +80,30 @@ test_discs = [
         id="ANJa4DGYN_ktpzOwvVPtcjwP7mE-",
         freedb="02025501",
     ),
+    DiscTestData(
+        name="Korn - See You on the Other Side, with pre-gap audio track",
+        first=1,
+        last=14,
+        sectors=275749,
+        offsets=[
+            5475,
+            19645,
+            34416,
+            51655,
+            68900,
+            90015,
+            111090,
+            130510,
+            158652,
+            173635,
+            189015,
+            208122,
+            224413,
+            252866,
+        ],
+        id="CnkXRItZOUxex7JwyWmHfdbFdqE-",
+        freedb="be0e130e",
+    ),
 ]
 
 
@@ -172,6 +196,7 @@ class TestModule(unittest.TestCase):
             self.assertEqual(disc.freedb_id, test_disc.freedb)
             self.assertEqual(disc.first_track_num, test_disc.first)
             self.assertEqual(disc.last_track_num, test_disc.last)
+            self.assertEqual(disc.pregap, test_disc.offsets[0])
             self.assertEqual(disc.sectors, test_disc.sectors)
             track_offsets = [track.offset for track in disc.tracks]
             self.assertEqual(track_offsets, list(test_disc.offsets))
@@ -226,6 +251,7 @@ class TestDisc(unittest.TestCase):
             disc.last_track_num, len(disc.tracks), "Wrong amount of tracks"
         )
         self.assertEqual(disc.sectors, disc.tracks[-1].offset + disc.tracks[-1].sectors)
+        self.assertEqual(disc.pregap, disc.tracks[0].offset)
 
         for track in disc.tracks:
             self.assertTrue(track.offset <= disc.sectors, "Invalid offset")


### PR DESCRIPTION
Add a `Disc.pregap` property for convenient access to the first track's pregap.